### PR TITLE
Add SMS ad generator example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# SMS Ad Generator
+
+This repository contains a simple example of generating SMS advertisement text using a Hugging Face model with LangChain.
+
+## Setup
+
+1. Create a Python virtual environment (optional but recommended):
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install dependencies. To use an RTX2000-series GPU, install PyTorch with CUDA support before installing the rest:
+   ```bash
+   pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu117
+   pip install -r requirements.txt
+   ```
+   The requirements file includes `transformers`, `langchain`, and other packages used by the script.
+
+## Usage
+
+Run the `ads_generator.py` script and provide the product or topic as an argument:
+
+```bash
+python ads_generator.py "Eco-friendly water bottles"
+```
+
+The script loads a text generation model from Hugging Face, creates a prompt with LangChain, and prints a short SMS advertisement message.

--- a/ads_generator.py
+++ b/ads_generator.py
@@ -1,0 +1,40 @@
+import argparse
+import torch
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer, pipeline
+from langchain.llms import HuggingFacePipeline
+from langchain.prompts import PromptTemplate
+from langchain.chains import LLMChain
+
+
+MODEL_NAME = "google/flan-t5-base"
+
+def load_model(model_name: str):
+    """Load a Hugging Face model and return a text-generation pipeline."""
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForSeq2SeqLM.from_pretrained(model_name)
+    device = 0 if torch.cuda.is_available() else -1
+    return pipeline("text2text-generation", model=model, tokenizer=tokenizer, device=device)
+
+
+def generate_ad(topic: str) -> str:
+    """Generate an SMS ad for the given topic."""
+    text_gen = load_model(MODEL_NAME)
+    hf_llm = HuggingFacePipeline(pipeline=text_gen)
+    prompt = PromptTemplate(
+        input_variables=["topic"],
+        template="Write a short and catchy SMS advertisement about {topic}."
+    )
+    chain = LLMChain(llm=hf_llm, prompt=prompt)
+    return chain.run(topic=topic).strip()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate SMS advertisement text")
+    parser.add_argument("topic", help="Product or topic of the advertisement")
+    args = parser.parse_args()
+    ad_text = generate_ad(args.topic)
+    print(ad_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+transformers
+langchain
+torch


### PR DESCRIPTION
## Summary
- add instructions for using huggingface and langchain to make SMS ads
- include ads_generator.py script with CLI
- document dependencies in requirements.txt

## Testing
- `python -m py_compile ads_generator.py`